### PR TITLE
Make mcp mandatory and extend tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "networkx>=2.6.0",
     "radon>=5.1.0",
     "pyyaml>=6.0",
+    "mcp>=0.9.0",
 ]
 
 [project.optional-dependencies]
@@ -37,9 +38,6 @@ dev = [
     "black>=22.0.0",
     "isort>=5.0.0",
     "mypy>=0.900",
-]
-mcp = [
-    "mcp>=0.9.0",
 ]
 
 [project.scripts]

--- a/pythonium/cli.py
+++ b/pythonium/cli.py
@@ -460,15 +460,7 @@ def main() -> None:
 @click.pass_context
 def mcp_server(ctx: click.Context, transport: str, host: str, port: int) -> None:
     """Start the Model Context Protocol (MCP) server for LLM agent integration."""
-    try:
-        from .mcp_server import PythoniumMCPServer, MCP_AVAILABLE
-    except ImportError:
-        click.echo("Error: MCP dependencies not found. Install with: pip install pythonium[mcp]", err=True)
-        ctx.exit(1)
-    
-    if not MCP_AVAILABLE:
-        click.echo("Error: MCP dependencies not available. Install with: pip install mcp", err=True)
-        ctx.exit(1)
+    from .mcp_server import PythoniumMCPServer
     
     import asyncio
     

--- a/pythonium/mcp/__init__.py
+++ b/pythonium/mcp/__init__.py
@@ -11,6 +11,8 @@ The server implementation features:
 - Robust error handling and validation
 """
 
+"""Expose :class:`PythoniumMCPServer`."""
+
 from .server import PythoniumMCPServer
 
 __all__ = ["PythoniumMCPServer"]

--- a/pythonium/mcp/core/middleware.py
+++ b/pythonium/mcp/core/middleware.py
@@ -9,11 +9,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from typing import Any, Awaitable, Callable, Dict, List
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 from ..utils.debug import info_log, warning_log, error_log
 from ..utils import Validator, ErrorHandler, PerformanceMonitor, ErrorContext, ErrorSeverity

--- a/pythonium/mcp/core/tool_registry.py
+++ b/pythonium/mcp/core/tool_registry.py
@@ -9,11 +9,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 from ..utils.debug import info_log, warning_log, error_log, profiler
 

--- a/pythonium/mcp/handlers/analysis.py
+++ b/pythonium/mcp/handlers/analysis.py
@@ -8,11 +8,7 @@ import asyncio
 from pathlib import Path
 from typing import Any, Dict, List
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 from pythonium.analyzer import Analyzer
 from pythonium.cli import find_project_root, get_or_create_config

--- a/pythonium/mcp/handlers/base.py
+++ b/pythonium/mcp/handlers/base.py
@@ -5,11 +5,7 @@ Base handler class with shared functionality for MCP tool handlers.
 from pathlib import Path
 from typing import Any, Dict, List, TYPE_CHECKING
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 from ..utils.debug import profiler, profile_operation, logger, info_log, warning_log, error_log
 from ..formatters import ResponseFormatter, ActionSuggestion

--- a/pythonium/mcp/handlers/composite.py
+++ b/pythonium/mcp/handlers/composite.py
@@ -4,11 +4,7 @@ Composite MCP tool handler that combines all handler modules.
 
 from typing import Any, Dict, List, TYPE_CHECKING
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 from .analysis import AnalysisHandlers
 from .execution import ExecutionHandlers

--- a/pythonium/mcp/handlers/execution.py
+++ b/pythonium/mcp/handlers/execution.py
@@ -7,11 +7,7 @@ import asyncio
 from pathlib import Path
 from typing import Any, Dict, List
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 from ..utils.debug import profiler, profile_operation
 from .base import BaseHandler

--- a/pythonium/mcp/handlers/issue_tracking.py
+++ b/pythonium/mcp/handlers/issue_tracking.py
@@ -5,11 +5,7 @@ Issue tracking MCP tool handlers for Pythonium.
 from pathlib import Path
 from typing import Any, Dict, List
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 from ..utils.debug import profiler, profile_operation, info_log
 from ..formatters import ActionSuggestion

--- a/pythonium/mcp/handlers/issue_tracking_new.py
+++ b/pythonium/mcp/handlers/issue_tracking_new.py
@@ -5,11 +5,7 @@ Issue tracking MCP tool handlers for Pythonium.
 from pathlib import Path
 from typing import Any, Dict, List
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 from ..utils.debug import profiler, profile_operation, info_log
 from ..formatters import ActionSuggestion

--- a/pythonium/mcp/server.py
+++ b/pythonium/mcp/server.py
@@ -9,15 +9,11 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Callable
 
-try:
-    import mcp.server.stdio
-    import mcp.server.sse
-    import mcp.types as types
-    from mcp.server import Server
-    from mcp.types import ServerCapabilities, ToolsCapability
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.server.stdio
+import mcp.server.sse
+import mcp.types as types
+from mcp.server import Server
+from mcp.types import ServerCapabilities, ToolsCapability
 
 from pythonium.analyzer import Analyzer
 from pythonium.cli import find_project_root, get_or_create_config
@@ -45,11 +41,6 @@ class PythoniumMCPServer:
     
     def __init__(self, name: str = "pythonium", version: str = "0.1.0", debug: bool = False):
         """Initialize the MCP server."""
-        if not MCP_AVAILABLE:
-            raise ImportError(
-                "MCP dependencies not available. Install with: "
-                "pip install mcp"
-            )
         
         # Setup logging
         if debug:

--- a/pythonium/mcp/tools/analysis.py
+++ b/pythonium/mcp/tools/analysis.py
@@ -6,11 +6,7 @@ Contains methods for analyzing issues, detector info, and reporting.
 from pathlib import Path
 from typing import Any, Dict, List
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 from ..utils.debug import info_log
 

--- a/pythonium/mcp/tools/configuration.py
+++ b/pythonium/mcp/tools/configuration.py
@@ -5,11 +5,7 @@ Contains methods for providing configuration schema documentation.
 
 from typing import Any, Dict, List
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 
 async def get_configuration_schema(server, arguments: Dict[str, Any]) -> List[types.TextContent]:

--- a/pythonium/mcp/tools/definitions.py
+++ b/pythonium/mcp/tools/definitions.py
@@ -3,17 +3,11 @@ Tool definitions for the Pythonium MCP server.
 Static tool definitions separated from main server logic.
 """
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 
 def get_tool_definitions() -> list:
     """Get MCP tool definitions."""
-    if not MCP_AVAILABLE:
-        return []
     
     return [
         types.Tool(

--- a/pythonium/mcp/utils/error_handling.py
+++ b/pythonium/mcp/utils/error_handling.py
@@ -12,11 +12,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, Type, Callable
 
-try:
-    import mcp.types as types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+import mcp.types as types
 
 from .debug import error_log, warning_log, info_log
 
@@ -186,17 +182,14 @@ class ErrorHandler:
     ) -> List[types.TextContent]:
         """
         Handle an error and generate appropriate response.
-        
+
         Args:
             exception: Exception to handle
             context: Error context
-            
+
         Returns:
             List of text content for MCP response
         """
-        if not MCP_AVAILABLE:
-            # Fallback if MCP types not available
-            return [{"type": "text", "text": f"Error: {str(exception)}"}]
         
         # Classify the error
         error_info = self._classify_error(exception, context)

--- a/pythonium/mcp_server.py
+++ b/pythonium/mcp_server.py
@@ -5,18 +5,14 @@ This module has been refactored into a modular structure for better maintainabil
 The main implementation is now in the mcp package.
 """
 
-# Check MCP availability early
-try:
-    import mcp.server.stdio
-    import mcp.types
-    MCP_AVAILABLE = True
-except ImportError:
-    MCP_AVAILABLE = False
+
+import mcp.server.stdio
+import mcp.types
 
 from pythonium.mcp import PythoniumMCPServer
 
 # Re-export for backward compatibility
-__all__ = ["PythoniumMCPServer", "MCP_AVAILABLE", "main"]
+__all__ = ["PythoniumMCPServer", "main"]
 
 def main():
     """Main entry point for MCP server."""

--- a/tests/mcp/test_analysis_additional.py
+++ b/tests/mcp/test_analysis_additional.py
@@ -50,19 +50,3 @@ async def test_analyze_issues_match_by_filename(tmp_path):
     assert "Pythonium Analysis Summary" in text
     assert "circular" in text
 
-
-def test_get_tool_definitions_missing_mcp(monkeypatch):
-    import pythonium.mcp.tools.definitions as definitions
-    original_import = builtins.__import__
-    def fake_import(name, *args, **kwargs):
-        if name == "mcp.types":
-            raise ImportError
-        return original_import(name, *args, **kwargs)
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-    importlib.reload(definitions)
-    try:
-        assert definitions.MCP_AVAILABLE is False
-        assert definitions.get_tool_definitions() == []
-    finally:
-        monkeypatch.setattr(builtins, "__import__", original_import)
-        importlib.reload(definitions)

--- a/tests/mcp/test_debug_profiler.py
+++ b/tests/mcp/test_debug_profiler.py
@@ -1,0 +1,35 @@
+import asyncio
+from pythonium.mcp.utils import debug
+from pythonium.mcp.utils.debug import OperationProfiler, profile_operation, setup_minimal_logging, setup_debug_logging
+
+
+def test_operation_profiler_basic(tmp_path):
+    setup_minimal_logging()
+    profiler = OperationProfiler()
+    profiler.start_operation('op', foo=1)
+    profiler.checkpoint('mid', step=2)
+    profiler.end_operation(success=True, bar=3)
+    report = profiler.get_report()
+    assert 'Operation: op' in report
+    assert 'Status: success' in report
+
+
+def test_profile_operation_decorator_sync_and_async():
+    setup_debug_logging()
+    debug.profiler.operations.clear()
+
+    @profile_operation('sync')
+    def add(a, b):
+        return a + b
+
+    @profile_operation('async')
+    async def add_async(a, b):
+        return a + b
+
+    assert add(2, 3) == 5
+    asyncio.run(add_async(1, 4))
+    names = [op['name'] for op in debug.profiler.operations]
+    assert names == ['sync', 'async']
+    for op in debug.profiler.operations:
+        assert op['status'] == 'success'
+

--- a/tests/mcp/test_error_handling.py
+++ b/tests/mcp/test_error_handling.py
@@ -1,0 +1,20 @@
+from pythonium.mcp.utils.error_handling import ErrorHandler, ErrorContext
+
+
+def test_handle_file_not_found_error():
+    handler = ErrorHandler()
+    result = handler.handle_error(FileNotFoundError("nope.txt"), ErrorContext(tool_name="x"))
+    assert "File not found" in result[0].text
+    assert "nope.txt" in result[0].text
+
+
+def test_handle_value_error_required():
+    handler = ErrorHandler()
+    result = handler.handle_error(ValueError("path required"), ErrorContext())
+    assert "Missing required parameter" in result[0].text
+
+
+def test_handle_value_error_generic():
+    handler = ErrorHandler()
+    result = handler.handle_error(ValueError("bad input"), ErrorContext())
+    assert "Invalid input" in result[0].text

--- a/tests/mcp/test_formatters.py
+++ b/tests/mcp/test_formatters.py
@@ -1,0 +1,38 @@
+import asyncio
+from pythonium.models import Issue, Location
+from pythonium.mcp.formatters.analysis_formatter import AnalysisFormatter
+from pythonium.mcp.formatters.agent_formatter import AgentFormatter
+from pythonium.mcp.formatters.text_converter import TextConverter
+from pythonium.mcp.formatters.data_models import ResponseData, ResponseType, WorkflowStage, WorkflowContext, ActionSuggestion
+
+
+def test_analysis_formatter_and_text_converter(tmp_path):
+    formatter = AnalysisFormatter()
+    issue = Issue(
+        id="i1",
+        severity="warn",
+        message="problem",
+        location=Location(file=tmp_path / "f.py", line=1),
+        detector_id="det1",
+    )
+    result = formatter.format_analysis_results([issue], str(tmp_path), tracked_count=1)
+    assert result.type == ResponseType.SUCCESS
+    assert "Found 1 code health issues" in result.message
+    text = TextConverter.to_text_content(result)
+    assert "Workflow Status" in text.text
+    assert "Mark issues" in text.text
+
+
+async def _async_agent_calls(issue_hash):
+    formatter = AgentFormatter()
+    note = formatter.format_agent_note_added(issue_hash, "investigated", "details", "res")
+    actions = formatter.format_agent_actions([{"action": "investigated"}], issue_hash)
+    complete = formatter.format_investigation_complete(issue_hash, "det", "finding")
+    return note, actions, complete
+
+
+def test_agent_formatter_async():
+    note, actions, complete = asyncio.run(_async_agent_calls("h"))
+    assert note.workflow_context.current_stage == WorkflowStage.INVESTIGATION
+    assert actions.metadata["action_count"] == 1
+    assert "investigation completed".split()[0] in TextConverter.to_text_content(complete).text.lower()

--- a/tests/mcp/test_issue_database_basic.py
+++ b/tests/mcp/test_issue_database_basic.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timezone
+from pythonium.models import Issue, Location
+from pythonium.mcp.storage.issue_database import IssueDatabase
+
+
+def make_issue(tmp_path, hash_id='h1'):
+    return Issue(
+        id='test.id',
+        severity='info',
+        message='msg',
+        location=Location(file=tmp_path / 'f.py', line=1),
+        detector_id='det',
+        issue_hash=hash_id,
+        first_seen=datetime.now(timezone.utc),
+        last_seen=datetime.now(timezone.utc),
+    )
+
+
+def test_issue_database_crud(tmp_path):
+    db = IssueDatabase(tmp_path)
+    issue = make_issue(tmp_path)
+    db.upsert_tracked_issue(issue)
+    assert db.has_issue('h1')
+    data = db.get_tracked_issue('h1')
+    assert data['id'] == 'test.id'
+
+    db.update_issue('h1', classification='false_positive', status='completed', notes=['n'])
+    updated = db.get_tracked_issue('h1')
+    assert updated['classification'] == 'false_positive'
+    assert updated['status'] == 'completed'
+
+    issues = db.list_issues()
+    assert len(issues) == 1
+    stats = db.get_statistics()
+    assert stats['total_tracked'] == 1
+
+    found = db.find_issue_by_location(tmp_path / 'f.py', 1)
+    assert found == 'h1'
+
+    db.update_issue_timestamp('h1')
+    assert db.get_tracked_issue('h1')['last_seen'] is not None
+
+    db.cleanup_stale_issues({'h1'})
+    assert db.has_issue('h1')

--- a/tests/mcp/test_issue_formatter.py
+++ b/tests/mcp/test_issue_formatter.py
@@ -1,0 +1,21 @@
+from pythonium.mcp.formatters.issue_formatter import IssueFormatter
+
+
+def test_issue_formatter_mark_and_list():
+    fmt = IssueFormatter()
+    res = fmt.format_issue_marked('h', 'true_positive', 'pending', 'note')
+    assert 'Issue h marked' in res.message
+    res_list = fmt.format_tracked_issues([
+        {'classification': 'unclassified', 'status': 'pending'},
+        {'classification': 'true_positive', 'status': 'work_in_progress'},
+    ])
+    assert 'Found 2 tracked issues' in res_list.message
+    res_info = fmt.format_issue_info(
+        {
+            'classification': 'true_positive',
+            'status': 'pending',
+            'original_issue': {'id': 'x'}
+        },
+        'h'
+    )
+    assert res_info.metadata['issue_hash'] == 'h'

--- a/tests/mcp/test_middleware_chain.py
+++ b/tests/mcp/test_middleware_chain.py
@@ -1,0 +1,37 @@
+import asyncio
+import mcp.types as types
+from pythonium.mcp.core.middleware import Middleware, MiddlewareChain
+
+
+class DummyMiddleware(Middleware):
+    def __init__(self, name, calls):
+        self.name = name
+        self.calls = calls
+
+    async def process(self, tool_name, arguments, next_handler):
+        self.calls.append(f"before-{self.name}")
+        result = await next_handler(tool_name, arguments)
+        self.calls.append(f"after-{self.name}")
+        return result
+
+
+def test_middleware_chain_add_remove_clear_execution():
+    calls = []
+    chain = MiddlewareChain()
+    m1 = DummyMiddleware('m1', calls)
+    m2 = DummyMiddleware('m2', calls)
+    chain.add(m1).add(m2)
+
+    async def final(name, args):
+        calls.append('final')
+        return [types.TextContent(type='text', text='done')]
+
+    result = asyncio.run(chain.process('tool', {}, final))
+    assert result[0].text == 'done'
+    assert calls == ['before-m1', 'before-m2', 'final', 'after-m2', 'after-m1']
+
+    assert chain.remove(DummyMiddleware)  # removes first occurrence
+    assert len(chain.get_middleware_info()) == 1
+    chain.clear()
+    assert chain.get_middleware_info() == []
+

--- a/tests/mcp/test_statistics_formatter.py
+++ b/tests/mcp/test_statistics_formatter.py
@@ -1,0 +1,15 @@
+from pythonium.mcp.formatters.statistics_formatter import StatisticsFormatter
+
+
+def test_statistics_formatter_basic():
+    stats = {
+        'total_tracked': 2,
+        'active': 1,
+        'suppressed': 0,
+        'by_classification': {'unclassified': 1},
+        'by_status': {'pending': 2}
+    }
+    fmt = StatisticsFormatter()
+    res = fmt.format_tracking_statistics(stats, project_path='p')
+    assert 'Issue tracking statistics' in res.message
+    assert res.workflow_context.current_stage == res.workflow_context.current_stage.__class__.CLASSIFICATION

--- a/tests/mcp/test_tool_registry.py
+++ b/tests/mcp/test_tool_registry.py
@@ -1,0 +1,33 @@
+import asyncio
+import mcp.types as types
+from pythonium.mcp.core.tool_registry import ToolRegistry
+
+
+def test_tool_registry_register_execute_unregister():
+    registry = ToolRegistry()
+    schema = types.Tool(name='hello', description='greet', inputSchema={})
+
+    async def handler(args):
+        return [types.TextContent(type='text', text=f"hi {args.get('name','')}" )]
+
+    registry.register('hello', handler, schema, category='greet')
+    assert registry.is_registered('hello')
+
+    result = asyncio.run(registry.execute_tool('hello', {'name': 'Alice'}))
+    assert result[0].text == 'hi Alice'
+
+    # error path
+    async def bad(args):
+        raise RuntimeError('boom')
+    registry.register('bad', bad, schema)
+    result = asyncio.run(registry.execute_tool('bad', {}))
+    assert 'Error executing tool' in result[0].text
+
+    info = registry.get_registry_info()
+    assert info['total_tools'] == 2
+    assert 'hello' in info['tools']
+
+    assert registry.unregister('hello')
+    assert not registry.is_registered('hello')
+    assert not registry.unregister('missing')
+

--- a/tests/mcp/test_validation_utils.py
+++ b/tests/mcp/test_validation_utils.py
@@ -1,0 +1,35 @@
+import pytest
+from pythonium.mcp.utils.validation import Validator, ValidationError, SchemaValidator
+
+
+def test_validator_basic_and_schema():
+    v = Validator()
+    v.validate_field('a', 'name', ['required', 'string'])
+    with pytest.raises(ValidationError):
+        v.validate_field('', 'name', ['required', 'non_empty_string'])
+
+    schema = {'n': ['required', 'string'], 'c': ['positive_integer']}
+    v.validate_schema({'n': 'x', 'c': 2}, schema)
+    with pytest.raises(ValidationError):
+        v.validate_schema({'n': 'x', 'c': 0}, schema)
+
+
+def test_schema_validator_configs():
+    sv = SchemaValidator()
+    sv.validate_detector_config({'enabled': True, 'severity': 'info', 'config': {}})
+    with pytest.raises(ValidationError):
+        sv.validate_detector_config({'enabled': 'yes', 'severity': 'info', 'config': {}})
+
+    sv.validate_analysis_config({'analysis': {'track_issues': True}, 'performance': {'max_workers': 1}})
+    with pytest.raises(ValidationError):
+        sv.validate_analysis_config({'performance': {'max_workers': 0}})
+
+    sv.validate_issue_data({
+        'id': '1',
+        'detector': 'd',
+        'severity': 'info',
+        'message': 'msg',
+        'file_path': 'f.py',
+        'line': 1
+    })
+

--- a/tests/mcp/test_workflow_guide.py
+++ b/tests/mcp/test_workflow_guide.py
@@ -1,0 +1,51 @@
+from pythonium.mcp.utils.workflow import WorkflowGuide
+from pythonium.mcp.formatters.data_models import WorkflowStage
+
+
+def test_assess_issue_complexity():
+    guide = WorkflowGuide()
+    issue = {
+        "detector_id": "security-smell",
+        "file_path": "src/auth/login.py",
+        "message": "possible security vulnerability"
+    }
+    assert guide.assess_issue_complexity(issue) == guide.detector_complexity_map["security-smell"]
+    simple_issue = {"detector_id": "dead-code", "file_path": "simple.py", "message": "unused"}
+    assert guide.assess_issue_complexity(simple_issue) == guide.detector_complexity_map["dead-code"]
+    project_context = {"total_issues": 150}
+    assert guide.assess_issue_complexity(simple_issue, project_context) != guide.detector_complexity_map["dead-code"]
+
+
+def test_create_workflow_plan():
+    guide = WorkflowGuide()
+    issues = [
+        {"detector_id": "dead-code", "classification": "unclassified", "status": "pending"},
+        {"detector_id": "circular-deps", "classification": "true_positive", "status": "pending"},
+    ]
+    plan = guide.create_workflow_plan(issues, WorkflowStage.DISCOVERY)
+    assert plan.complexity.value in {c.value for c in guide.detector_complexity_map.values()}
+    assert WorkflowStage.INVESTIGATION in plan.stages
+
+
+def test_suggest_and_estimate_and_blockers():
+    guide = WorkflowGuide()
+    issues = [
+        {
+            "detector_id": "security-smell",
+            "classification": "unclassified",
+            "status": "pending",
+            "file_path": "auth/app.py"
+        },
+        {
+            "detector_id": "dead-code",
+            "classification": "true_positive",
+            "status": "pending",
+            "file_path": "src/foo.py"
+        }
+    ]
+    suggestions = guide.suggest_next_actions(WorkflowStage.INVESTIGATION, issues)
+    assert any(s.action == "classify_investigated" for s in suggestions)
+    total, stages = guide.estimate_completion_time(issues, WorkflowStage.RESOLUTION)
+    assert "Resolution" in stages
+    blockers = guide.identify_blockers(issues)
+    assert any("security" in b.lower() for b in blockers)


### PR DESCRIPTION
## Summary
- depend on the `mcp` package by default
- drop `MCP_AVAILABLE` fallbacks in mcp modules
- clean up CLI startup checks
- remove test stubs and cover more branches
- expand workflow and analysis tool tests

## Testing
- `coverage run --source=pythonium/mcp -m pytest -q`
- `coverage report --omit="tests/*"`

------
https://chatgpt.com/codex/tasks/task_e_68597189807c8324936b7df8182e3aeb